### PR TITLE
Rename class to avoid name collision with MariaDB4jSpringService from springboot module

### DIFF
--- a/mariaDB4j-app/pom.xml
+++ b/mariaDB4j-app/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.craftercms.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.3.0.1</version>
+        <version>3.3.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.craftercms.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.3.0.1</version>
+        <version>3.3.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/springframework/MariaDB4jCoreSpringService.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/springframework/MariaDB4jCoreSpringService.java
@@ -45,9 +45,11 @@ import java.util.Objects;
  * don't want it to be auto-started by component scan without explicit declaration in
  * a @Configuration (or XML)
  *
- * @author Michael Vorburger
+ * @author Michael Vorburger Note: Notice this class was moved to springboot module in upstream
+ *     repository. We are keeping it here (although renamed to avoid collission) to support Studio
+ *     which uses Spring Framework but not Spring Boot.
  */
-public class MariaDB4jSpringService extends MariaDB4jService implements Lifecycle {
+public class MariaDB4jCoreSpringService extends MariaDB4jService implements Lifecycle {
 
     public static final String PORT = "mariaDB4j.port";
     public static final String SOCKET = "mariaDB4j.socket";

--- a/mariaDB4j-junit/pom.xml
+++ b/mariaDB4j-junit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.craftercms.mariaDB4j</groupId>
     <artifactId>mariaDB4j-pom</artifactId>
-    <version>3.3.0.1</version>
+    <version>3.3.0.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mariaDB4j-maven-plugin/pom.xml
+++ b/mariaDB4j-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.craftercms.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.3.0.1</version>
+        <version>3.3.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mariaDB4j-pom-lite/pom.xml
+++ b/mariaDB4j-pom-lite/pom.xml
@@ -14,7 +14,7 @@
          DBs/mariaDB4j-db-*/pom.xml versions (as those are also always
          non-SNAPSHOT, existing ones do NOT get changed).
      -->
-    <version>3.3.0.1</version>
+    <version>3.3.0.2</version>
     <packaging>pom</packaging>
 
     <name>MariaDB4j POM Lite</name>

--- a/mariaDB4j-springboot/pom.xml
+++ b/mariaDB4j-springboot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.craftercms.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.3.0.1</version>
+        <version>3.3.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mariaDB4j/pom.xml
+++ b/mariaDB4j/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.craftercms.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.3.0.1</version>
+        <version>3.3.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
         <artifactId>mariaDB4j-pom-lite</artifactId>
         <!-- Do NOT depend on a SNAPSHOT here!
              Note that this parent version and the version below are, intentionally, completely unrelated. -->
-        <version>3.3.0.1</version>
+        <version>3.3.0.2</version>
         <relativePath>mariaDB4j-pom-lite/pom.xml</relativePath>
     </parent>
 
     <artifactId>mariaDB4j-pom</artifactId>
     <name>MariaDB4j POM</name>
-    <version>3.3.0.1</version>
+    <version>3.3.0.2</version>
     <packaging>pom</packaging>
 
     <scm>


### PR DESCRIPTION
Rename class to avoid name collision with MariaDB4jSpringService from springboot module
https://github.com/craftersoftware/craftercms/issues/1209